### PR TITLE
Add instructions to use without cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ First, obtain a source pixel-art-style image (e.g. a pixel-art-style image gener
 
 ```bash
 uv run ppa -i <input_path> -o <output_path> -c <num_colors> -p <pixel_size> [-t]
+# or directly using uvx
+uvx --from https://github.com/KennethJAllen/proper-pixel-art.git ppa -i <input_path> -o <output_path> -c <num_colors> -p <pixel_size> [-t]
 ```
 
 ### Flags


### PR DESCRIPTION
Since the README includes instructions involving `uv` it might be nice to tell users that they can use the cli directly using `uvx`

---

Note: I noticed that the assets/data files are quite large. Maybe they can be compressed or provide a minimal example(?)