### PR TITLE
Adds options pixel-width and upscale-factor

### DIFF
--- a/proper_pixel_art/cli.py
+++ b/proper_pixel_art/cli.py
@@ -43,6 +43,22 @@ def parse_args() -> argparse.Namespace:
         default=False,
         help="Produce a transparent background in the output if set."
     )
+    parser.add_argument(
+        "-w",
+        "--pixel-width",
+        dest="pixel_width",
+        type=int,
+        default=None,
+        help="Width of the pixels in the input image. If not set, it will be determined automatically."
+    )
+    parser.add_argument(
+        "-s",
+        "--upscale-factor",
+        dest="upscale_factor",
+        type=int,
+        default=2,
+        help="Image upscale factor."
+    )
     return parser.parse_args()
 
 def resolve_output_path(out_path: Path, input_path: Path, suffix: str = "_pixelated") -> Path:
@@ -66,7 +82,9 @@ def main() -> None:
         img,
         num_colors = args.num_colors,
         pixel_size = args.pixel_size,
-        transparent_background = args.transparent
+        transparent_background = args.transparent,
+        pixel_width = args.pixel_width,
+        initial_upsample_factor = args.upscale_factor
         )
 
     pixelated.save(out_path)

--- a/proper_pixel_art/pixelate.py
+++ b/proper_pixel_art/pixelate.py
@@ -9,6 +9,7 @@ def pixelate(
         pixel_size: int | None = None,
         transparent_background: bool = False,
         intermediate_dir: Path | None = None,
+        pixel_width: int | None = None
         ) -> Image.Image:
     """
     Computes the true resolution pixel art image.
@@ -33,7 +34,12 @@ def pixelate(
     """
     rgba = image.convert("RGBA")
 
-    mesh_lines, scaled_img = mesh.compute_mesh_with_scaling(rgba, initial_upsample_factor, output_dir=intermediate_dir)
+    mesh_lines, scaled_img = mesh.compute_mesh_with_scaling(
+        rgba,
+        initial_upsample_factor,
+        output_dir=intermediate_dir,
+        pixel_width=pixel_width
+    )
 
     paletted_img = colors.palette_img(scaled_img, num_colors=num_colors)
 


### PR DESCRIPTION
For my grass tile the tool hasn't worked out of the box. By exposing the two settings "pixel width" and "upscale factor" I was able to receive something that was more like what I've expected.

## Test

Input image:

<img width="1024" height="1024" alt="grass_tile_input" src="https://github.com/user-attachments/assets/ffeca498-72cb-41f2-a8cb-6769a52d6633" />


### Before the changes

```
 uv run ppa -i grass_tile_input.png -o grass_tile_before.png -c 32
```

Output:

<img width="10" height="10" alt="grass_tile_before" src="https://github.com/user-attachments/assets/994a98f5-40f7-4022-a474-08e1bd2fffa5" />

### After the changes

```
uv run ppa -i grass_tile_input.png -o grass_tile_after.png -c 32 -w 22 -s 1
```

Output:

<img width="45" height="46" alt="grass_tile_after" src="https://github.com/user-attachments/assets/76214106-dd68-4760-84fb-d6fb5733cea8" />

Pixel width was manually measured.
