### PR TITLE
Add output size to output suffix

### DIFF
--- a/proper_pixel_art/cli.py
+++ b/proper_pixel_art/cli.py
@@ -150,9 +150,6 @@ def main() -> None:
     args = parse_args()
     input_path = Path(args.input_path).expanduser()
 
-    out_path = resolve_output_path(Path(args.out_path), input_path)
-    out_path.parent.mkdir(exist_ok=True, parents=True)
-
     config = PixelateConfig.from_yaml(args.config) if args.config else None
 
     # Each arg's dest matches a pixelate kwarg; None values fall back to config.
@@ -172,6 +169,13 @@ def main() -> None:
     pixelated = pixelate(
         img, config=config, intermediate_dir=args.intermediate_dir, **overrides
     )
+
+    width, height = pixelated.size
+
+    out_path = resolve_output_path(
+        Path(args.out_path), input_path, f"_{width}x{height}"
+    )
+    out_path.parent.mkdir(exist_ok=True, parents=True)
 
     pixelated.save(out_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,12 +36,12 @@ def test_main_writes_output_file(
 def test_main_output_to_directory(
     monkeypatch: pytest.MonkeyPatch, assets: Path, tmp_path: Path
 ) -> None:
-    """A directory output path gets the default '<stem>_pixelated.png' name."""
+    """A directory output path gets the default '<stem>_<W>x<H>.png' name."""
     input_path = assets / "anchor" / "anchor.png"
 
     run_cli(monkeypatch, str(input_path), "-o", str(tmp_path), "-c", "8")
 
-    assert (tmp_path / "anchor_pixelated.png").is_file()
+    assert (tmp_path / "anchor_32x32.png").is_file()
 
 
 def test_main_requires_input_path(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Add output size to _default CLI_ output suffix. Simple put powerful extension, helps with both general naming and verifying if the conversion was completed as intended.

This could be a somewhat breaking change, but I see it as unintrusive here because default CLI output naming was an implementation detail so far (couple of versions ago default output path wasn't even a thing e.g. :), and the change happens only on `main` level here. All the other (deeper) existing functions are untouched, meaning that for any integration not using CLI's `main` the previous `_pixelated` syntax is still correct.