### PR TITLE
Add host and port argument parsing to ppa-web CLI

### DIFF
--- a/proper_pixel_art/web.py
+++ b/proper_pixel_art/web.py
@@ -113,4 +113,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/proper_pixel_art/web.py
+++ b/proper_pixel_art/web.py
@@ -90,9 +90,27 @@ def create_demo():
 
 def main():
     """Entry point for ppa-web command."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Web interface for Proper Pixel Art")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="Host address to bind the server to (e.g., 127.0.0.1 or 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port to run the server on (e.g., 7860)",
+    )
+    args = parser.parse_args()
+
     demo = create_demo()
-    demo.launch()
+    demo.launch(server_name=args.host, server_port=args.port)
 
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -21,9 +21,7 @@ def test_web_main_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_web_main_custom_host_port(monkeypatch: pytest.MonkeyPatch) -> None:
     """Check that web.main() parses --host and --port and passes them to demo.launch."""
-    monkeypatch.setattr(
-        sys, "argv", ["ppa-web", "--host", "0.0.0.0", "--port", "8080"]
-    )
+    monkeypatch.setattr(sys, "argv", ["ppa-web", "--host", "0.0.0.0", "--port", "8080"])
 
     mock_demo = MagicMock()
     with patch("proper_pixel_art.web.create_demo", return_value=mock_demo):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,32 @@
+"""Tests for the ``ppa-web`` command line interface."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from proper_pixel_art import web
+
+
+def test_web_main_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check that web.main() launches with default server_name and server_port as None."""
+    monkeypatch.setattr(sys, "argv", ["ppa-web"])
+
+    mock_demo = MagicMock()
+    with patch("proper_pixel_art.web.create_demo", return_value=mock_demo):
+        web.main()
+
+    mock_demo.launch.assert_called_once_with(server_name=None, server_port=None)
+
+
+def test_web_main_custom_host_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check that web.main() parses --host and --port and passes them to demo.launch."""
+    monkeypatch.setattr(
+        sys, "argv", ["ppa-web", "--host", "0.0.0.0", "--port", "8080"]
+    )
+
+    mock_demo = MagicMock()
+    with patch("proper_pixel_art.web.create_demo", return_value=mock_demo):
+        web.main()
+
+    mock_demo.launch.assert_called_once_with(server_name="0.0.0.0", server_port=8080)


### PR DESCRIPTION
A minor change that adds argument parsing to `ppa-web`  to specify the host and port for the web server.

Uses `argparse` for `--host` and `--port` options for address binding and port. It's then passed to `demo.launch()` which already has provisions for this as `server_name` and `server_port`.

#### Usage

```
ppa-web --host 0.0.0.0 --port 8080
```


