### PR TITLE
feat: add AI pixel art diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ ppa <input_path> -o <output_path> -c <num_colors> -s <result_scale> [-t]
 | `-w`, `--pixel-width` `<int>`     | Width of the pixels in the input image. Use 0 to determine it automatically. (default: 0)                 |
 | `--config` `<path>`               | YAML config file of pixelation parameters. Flags passed explicitly override values in the file. (default: none) |
 | `--intermediate-dir` `<path>`     | Directory to save images visualizing intermediate algorithm steps. Useful for development. (default: none) |
+| `--diagnose`                      | Analyze the input image and print a diagnostic report (size, colors, transparency, noise) instead of pixelating. Still images only. (default: off) |
 
 #### Example
 

--- a/proper_pixel_art/cli.py
+++ b/proper_pixel_art/cli.py
@@ -1,4 +1,4 @@
-"""Command line interface"""
+"""Command line interface."""
 
 import argparse
 from importlib.metadata import version
@@ -8,10 +8,11 @@ from PIL import Image
 
 from proper_pixel_art import pixelate, utils
 from proper_pixel_art.config import PixelateConfig
+from proper_pixel_art.diagnostics import diagnose_image, format_diagnostics
 
 # Inputs with these suffixes are dispatched to the video pipeline; everything
 # else is treated as a still image. GIFs always take the video path, which
-# preserves animation (and handles single-frame GIFs fine).
+# preserves animation and handles single-frame GIFs correctly.
 VIDEO_SUFFIXES = frozenset({".mp4", ".gif", ".webm", ".mov", ".avi", ".mkv", ".m4v"})
 
 
@@ -21,25 +22,23 @@ def add_pixelation_args(
 ) -> argparse.ArgumentParser:
     """Add common pixelation arguments to an argument parser.
 
-    Every flag defaults to ``None`` (meaning "not provided"), so unset flags fall
-    back to the config / built-in defaults inside ``pixelate``.
-
-    Args:
-        parser: The argument parser to add arguments to
-        group_name: Name of the argument group (default: "Pixelation options")
-
-    Returns:
-        The parser with pixelation arguments added
+    Every flag defaults to ``None`` meaning "not provided". Unset flags fall
+    back to the config or built-in defaults inside ``pixelate``.
     """
     pixel_group = parser.add_argument_group(group_name)
+
     pixel_group.add_argument(
         "-c",
         "--colors",
         dest="num_colors",
         type=int,
         default=None,
-        help="Number of colors to quantize the image to (1-256). Use 0 to skip quantization and preserve all colors.",
+        help=(
+            "Number of colors to quantize the image to (1-256). "
+            "Use 0 to skip quantization and preserve all colors."
+        ),
     )
+
     pixel_group.add_argument(
         "-s",
         "--scale-result",
@@ -48,6 +47,7 @@ def add_pixelation_args(
         default=None,
         help="Width of the 'pixels' in the output image (1 = no scaling).",
     )
+
     pixel_group.add_argument(
         "-t",
         "--transparent",
@@ -56,14 +56,19 @@ def add_pixelation_args(
         default=None,
         help="Produce a transparent background in the output if set.",
     )
+
     pixel_group.add_argument(
         "-w",
         "--pixel-width",
         dest="pixel_width",
         type=int,
         default=None,
-        help="Width of the pixels in the input image. Use 0 (or omit) to determine it automatically.",
+        help=(
+            "Width of the pixels in the input image. "
+            "Use 0 or omit it to determine the width automatically."
+        ),
     )
+
     pixel_group.add_argument(
         "-u",
         "--initial-upscale",
@@ -71,15 +76,23 @@ def add_pixelation_args(
         type=int,
         default=None,
         help=(
-            "Initial image upscale factor in mesh detection algorithm. "
-            "If the detected spacing is too large, "
-            "it may be useful to increase this value."
+            "Initial image upscale factor in the mesh detection algorithm. "
+            "If the detected spacing is too large, it may be useful to "
+            "increase this value."
         ),
     )
+
+    parser.add_argument(
+        "--diagnose",
+        action="store_true",
+        help="Analyze the input image without pixelating it.",
+    )
+
     return parser
 
 
-# Each dest added by add_pixelation_args matches a pixelate/pixelate_video kwarg.
+# Each destination added by add_pixelation_args matches a
+# pixelate/pixelate_video keyword argument.
 PIXELATION_FIELDS = (
     "num_colors",
     "scale_result",
@@ -89,9 +102,12 @@ PIXELATION_FIELDS = (
 )
 
 
-def add_video_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Add the video/GIF-only arguments (ignored for image inputs)."""
+def add_video_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Add video/GIF-only arguments."""
     video_group = parser.add_argument_group("Video/GIF options")
+
     video_group.add_argument(
         "-f",
         "--format",
@@ -99,10 +115,11 @@ def add_video_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         choices=["mp4", "gif"],
         default=None,
         help=(
-            "Output format (default: inferred from output extension, then input extension). "
-            "Applies to video/GIF inputs only; ignored for images."
+            "Output format. Defaults to the output extension, then the input "
+            "extension. Applies to video/GIF inputs only; ignored for images."
         ),
     )
+
     video_group.add_argument(
         "-n",
         "--sample-frames",
@@ -114,69 +131,91 @@ def add_video_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
             "Applies to video/GIF inputs only; ignored for images."
         ),
     )
+
     return parser
 
 
-def add_config_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Add the ``--config`` / ``--intermediate-dir`` arguments shared by both CLIs."""
+def add_config_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Add shared config and intermediate-output arguments."""
     parser.add_argument(
         "--config",
         dest="config",
         type=Path,
         default=None,
-        help="Path to a YAML config file of pixelation parameters. Any flags passed explicitly override values in the file.",
+        help=(
+            "Path to a YAML config file of pixelation parameters. "
+            "Explicit flags override values from the config file."
+        ),
     )
+
     parser.add_argument(
         "--intermediate-dir",
         dest="intermediate_dir",
         type=Path,
         default=None,
-        help="Directory to save images visualizing intermediate algorithm steps (created if needed).",
+        help=(
+            "Directory to save images visualizing intermediate algorithm "
+            "steps. Created if needed."
+        ),
     )
+
     return parser
 
 
-def collect_pixelation_overrides(args: argparse.Namespace) -> dict:
-    """Collect the explicit pixelation flag values from parsed args.
+def collect_pixelation_overrides(
+    args: argparse.Namespace,
+) -> dict:
+    """Collect explicit pixelation flag values from parsed arguments.
 
-    Values are ``None`` when the flag wasn't provided, so they fall back to
-    the config / built-in defaults downstream.
+    Values are ``None`` when a flag was not provided, allowing downstream
+    functions to use config or built-in defaults.
     """
     return {field: getattr(args, field) for field in PIXELATION_FIELDS}
 
 
 def resolve_input_path(
-    parser: argparse.ArgumentParser, args: argparse.Namespace
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
 ) -> argparse.Namespace:
-    """Resolve the positional input path against the ``-i``/``--input`` flag,
-    erroring out when neither is given."""
+    """Resolve the positional input path against the ``-i`` flag."""
     if args.input_path is None and args.input_path_flag is None:
-        parser.error("You must provide an input path (positional or with -i).")
+        parser.error(
+            "You must provide an input path (positionally or with -i/--input)."
+        )
+
     args.input_path = (
         args.input_path if args.input_path is not None else args.input_path_flag
     )
+
     return args
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Generate true-resolution pixel art from a source image, video, or GIF. "
-            "Video and GIF inputs are auto-detected and dispatched to the video pipeline."
+            "Generate true-resolution pixel art from a source image, "
+            "video, or GIF. Video and GIF inputs are automatically "
+            "dispatched to the video pipeline."
         )
     )
+
     parser.add_argument(
         "-V",
         "--version",
         action="version",
         version=f"%(prog)s {version('proper-pixel-art')}",
     )
+
     parser.add_argument(
         "input_path",
         type=Path,
         nargs="?",
         help="Path to the source image, video, or GIF.",
     )
+
     parser.add_argument(
         "-i",
         "--input",
@@ -185,58 +224,88 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help=argparse.SUPPRESS,
     )
+
     parser.add_argument(
         "-o",
         "--output",
         dest="out_path",
         type=Path,
         default=Path("."),
-        help="Path where the pixelated image will be saved. Can be either a directory or a file path.",
+        help=(
+            "Path where the pixelated image will be saved. "
+            "Can be either a directory or a file path."
+        ),
     )
-    add_config_args(parser)
 
-    # Flags default to None so unset ones fall back to --config; see pixelate().
+    add_config_args(parser)
     add_pixelation_args(parser)
     add_video_args(parser)
 
     args = parser.parse_args()
 
-    # Either take the input as the first argument or use the -i flag
     return resolve_input_path(parser, args)
 
 
 def resolve_output_path(
-    out_path: Path, input_path: Path, suffix: str = "_pixelated"
+    out_path: Path,
+    input_path: Path,
+    suffix: str = "_pixelated",
 ) -> Path:
-    """
-    If out_path is a directory, make it a file path with filename
-    ``(input stem){suffix}.png`` (main passes the output size as the suffix,
-    e.g. ``sprite_128x128.png``). An out_path that already names a file is
-    returned unchanged.
-    """
-    return utils.build_output_path(out_path, input_path, suffix, ext="png")
+    """Resolve the final output path."""
+    return utils.build_output_path(
+        out_path,
+        input_path,
+        suffix,
+        ext="png",
+    )
+
+
+def run_diagnostics(input_path: Path) -> None:
+    """Analyze a still image and print the diagnostic report."""
+    with Image.open(input_path) as image:
+        diagnostics = diagnose_image(image)
+
+    print(format_diagnostics(diagnostics))
 
 
 def main() -> None:
+    """Run the command-line application."""
     args = parse_args()
     input_path = Path(args.input_path).expanduser()
 
+    if not input_path.exists():
+        raise SystemExit(f"Input file does not exist: {input_path}")
+
+    if not input_path.is_file():
+        raise SystemExit(f"Input path is not a file: {input_path}")
+
+    is_video = input_path.suffix.lower() in VIDEO_SUFFIXES
+
+    if args.diagnose:
+        if is_video:
+            raise SystemExit(
+                "--diagnose currently supports still images only. "
+                "Video and GIF diagnostics are not supported yet."
+            )
+
+        run_diagnostics(input_path)
+        return
+
     config = PixelateConfig.from_yaml(args.config) if args.config else None
 
-    # None values fall back to config / built-in defaults inside pixelate.
+    # None values fall back to config or built-in defaults inside pixelate.
     overrides = collect_pixelation_overrides(args)
 
-    # Debug images go in a per-input subdirectory named after the input stem
-    # (e.g. --intermediate-dir foo + wisp.mp4 -> foo/wisp/), mirroring the
-    # stem-based output-path convention and keeping multiple runs from
-    # clobbering each other in a shared directory.
+    # Debug images go into a per-input subdirectory named after the input
+    # stem, for example: foo/wisp/.
     intermediate_dir = args.intermediate_dir
+
     if intermediate_dir is not None:
         intermediate_dir = intermediate_dir / input_path.stem
         intermediate_dir.mkdir(parents=True, exist_ok=True)
 
-    if input_path.suffix.lower() in VIDEO_SUFFIXES:
-        # Deferred import so image runs don't pay the cv2 import cost.
+    if is_video:
+        # Deferred import so image runs do not pay the video import cost.
         from proper_pixel_art import video
 
         video.pixelate_video(
@@ -250,18 +319,23 @@ def main() -> None:
         )
         return
 
-    img = Image.open(input_path)
-    pixelated = pixelate(
-        img, config=config, intermediate_dir=intermediate_dir, **overrides
-    )
+    with Image.open(input_path) as image:
+        pixelated = pixelate(
+            image,
+            config=config,
+            intermediate_dir=intermediate_dir,
+            **overrides,
+        )
 
     width, height = pixelated.size
 
     out_path = resolve_output_path(
-        Path(args.out_path), input_path, f"_{width}x{height}"
+        Path(args.out_path),
+        input_path,
+        f"_{width}x{height}",
     )
-    out_path.parent.mkdir(exist_ok=True, parents=True)
 
+    out_path.parent.mkdir(exist_ok=True, parents=True)
     pixelated.save(out_path)
 
 

--- a/proper_pixel_art/cli.py
+++ b/proper_pixel_art/cli.py
@@ -16,6 +16,11 @@ from proper_pixel_art.diagnostics import diagnose_image, format_diagnostics
 # preserves animation and handles single-frame GIFs correctly.
 VIDEO_SUFFIXES = frozenset({".mp4", ".gif", ".webm", ".mov", ".avi", ".mkv", ".m4v"})
 
+# Effective defaults for flags that parse as None so that "not provided" is
+# observable (--diagnose warns about explicitly passed flags it ignores).
+DEFAULT_OUT_PATH = Path(".")
+DEFAULT_SAMPLE_FRAMES = 8
+
 
 def add_pixelation_args(
     parser: argparse.ArgumentParser,
@@ -120,10 +125,11 @@ def add_video_args(
         "--sample-frames",
         dest="sample_frames",
         type=int,
-        default=8,
+        default=None,
         help=(
-            "Number of frames to sample for mesh detection (default: 8). "
-            "Applies to video/GIF inputs only; ignored for images."
+            f"Number of frames to sample for mesh detection "
+            f"(default: {DEFAULT_SAMPLE_FRAMES}). "
+            f"Applies to video/GIF inputs only; ignored for images."
         ),
     )
 
@@ -225,10 +231,11 @@ def parse_args() -> argparse.Namespace:
         "--output",
         dest="out_path",
         type=Path,
-        default=Path("."),
+        default=None,
         help=(
             "Path where the pixelated image will be saved. "
-            "Can be either a directory or a file path."
+            "Can be either a directory or a file path "
+            "(default: the current directory)."
         ),
     )
 
@@ -246,6 +253,7 @@ def parse_args() -> argparse.Namespace:
     add_video_args(parser)
 
     args = parser.parse_args()
+    args.diagnose_ignored_flags = collect_ignored_diagnose_flags(parser, args)
 
     return resolve_input_path(parser, args)
 
@@ -255,7 +263,12 @@ def resolve_output_path(
     input_path: Path,
     suffix: str = "_pixelated",
 ) -> Path:
-    """Resolve the final output path."""
+    """
+    If out_path is a directory, make it a file path with filename
+    ``(input stem){suffix}.png`` (main passes the output size as the suffix,
+    e.g. ``sprite_128x128.png``). An out_path that already names a file is
+    returned unchanged.
+    """
     return utils.build_output_path(
         out_path,
         input_path,
@@ -264,33 +277,37 @@ def resolve_output_path(
     )
 
 
-# Flags that --diagnose does not act on, mapped to their user-facing names.
-# Only flags defaulting to None are listed: for those, a non-None value means
-# the user passed them explicitly. -o/--output and -n/--sample-frames have
-# non-None defaults, so an explicit value is indistinguishable from the
-# default and they are left out.
-DIAGNOSE_IGNORED_FLAGS = (
-    ("num_colors", "-c/--colors"),
-    ("scale_result", "-s/--scale-result"),
-    ("transparent_background", "-t/--transparent"),
-    ("pixel_width", "-w/--pixel-width"),
-    ("initial_upscale_factor", "-u/--initial-upscale"),
-    ("config", "--config"),
-    ("intermediate_dir", "--intermediate-dir"),
-    ("output_format", "-f/--format"),
-)
+# The only flags --diagnose acts on; every other flag defaults to None so a
+# non-None value proves the user passed it and earns a warning below.
+_DIAGNOSE_USED_DESTS = frozenset({"input_path_flag", "diagnose"})
+
+
+def collect_ignored_diagnose_flags(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> list[str]:
+    """List user-facing names of explicitly passed flags --diagnose ignores.
+
+    Derived from the parser's registered actions rather than a hand-written
+    table, so new flags are covered automatically. Positionals and the
+    built-in help/version actions (which default to SUPPRESS, not None) fall
+    out of the filters naturally.
+    """
+    return [
+        "/".join(action.option_strings)
+        for action in parser._actions
+        if action.option_strings
+        and action.default is None
+        and action.dest not in _DIAGNOSE_USED_DESTS
+        and getattr(args, action.dest) is not None
+    ]
 
 
 def warn_ignored_diagnose_flags(args: argparse.Namespace) -> None:
     """Warn about explicitly passed flags that ``--diagnose`` ignores."""
-    names = [
-        name
-        for dest, name in DIAGNOSE_IGNORED_FLAGS
-        if getattr(args, dest, None) is not None
-    ]
-
-    if names:
-        print(f"Warning: --diagnose ignores: {', '.join(names)}", file=sys.stderr)
+    if args.diagnose_ignored_flags:
+        ignored = ", ".join(args.diagnose_ignored_flags)
+        print(f"Warning: --diagnose ignores: {ignored}", file=sys.stderr)
 
 
 def run_diagnostics(input_path: Path) -> None:
@@ -306,8 +323,16 @@ def main() -> None:
     args = parse_args()
     input_path = Path(args.input_path).expanduser()
 
-    if not input_path.exists():
-        raise SystemExit(f"Input file does not exist: {input_path}")
+    # stat() (unlike exists()) distinguishes a missing file from one that is
+    # unreadable, e.g. behind a permission-blocked directory.
+    try:
+        input_path.stat()
+    except FileNotFoundError:
+        raise SystemExit(f"Input file does not exist: {input_path}") from None
+    except OSError as error:
+        raise SystemExit(
+            f"Cannot access input file: {input_path} ({error.strerror})"
+        ) from None
 
     if not input_path.is_file():
         raise SystemExit(f"Input path is not a file: {input_path}")
@@ -331,23 +356,33 @@ def main() -> None:
     # None values fall back to config or built-in defaults inside pixelate.
     overrides = collect_pixelation_overrides(args)
 
-    # Debug images go into a per-input subdirectory named after the input
-    # stem, for example: foo/wisp/.
+    # Debug images go in a per-input subdirectory named after the input stem
+    # (e.g. --intermediate-dir foo + wisp.mp4 -> foo/wisp/), mirroring the
+    # stem-based output-path convention and keeping multiple runs from
+    # clobbering each other in a shared directory.
     intermediate_dir = args.intermediate_dir
 
     if intermediate_dir is not None:
         intermediate_dir = intermediate_dir / input_path.stem
         intermediate_dir.mkdir(parents=True, exist_ok=True)
 
+    out_path = args.out_path if args.out_path is not None else DEFAULT_OUT_PATH
+
     if is_video:
         # Deferred import so image runs do not pay the video import cost.
         from proper_pixel_art import video
 
+        sample_frames = (
+            args.sample_frames
+            if args.sample_frames is not None
+            else DEFAULT_SAMPLE_FRAMES
+        )
+
         video.pixelate_video(
             input_path=input_path,
-            output_path=Path(args.out_path),
+            output_path=out_path,
             output_format=args.output_format,
-            num_sample_frames=args.sample_frames,
+            num_sample_frames=sample_frames,
             intermediate_dir=intermediate_dir,
             config=config,
             **overrides,
@@ -365,7 +400,7 @@ def main() -> None:
     width, height = pixelated.size
 
     out_path = resolve_output_path(
-        Path(args.out_path),
+        out_path,
         input_path,
         f"_{width}x{height}",
     )

--- a/proper_pixel_art/cli.py
+++ b/proper_pixel_art/cli.py
@@ -1,6 +1,7 @@
 """Command line interface."""
 
 import argparse
+import sys
 from importlib.metadata import version
 from pathlib import Path
 
@@ -80,12 +81,6 @@ def add_pixelation_args(
             "If the detected spacing is too large, it may be useful to "
             "increase this value."
         ),
-    )
-
-    parser.add_argument(
-        "--diagnose",
-        action="store_true",
-        help="Analyze the input image without pixelating it.",
     )
 
     return parser
@@ -237,6 +232,15 @@ def parse_args() -> argparse.Namespace:
         ),
     )
 
+    parser.add_argument(
+        "--diagnose",
+        action="store_true",
+        help=(
+            "Analyze the input image and print a diagnostic report "
+            "instead of pixelating it."
+        ),
+    )
+
     add_config_args(parser)
     add_pixelation_args(parser)
     add_video_args(parser)
@@ -258,6 +262,35 @@ def resolve_output_path(
         suffix,
         ext="png",
     )
+
+
+# Flags that --diagnose does not act on, mapped to their user-facing names.
+# Only flags defaulting to None are listed: for those, a non-None value means
+# the user passed them explicitly. -o/--output and -n/--sample-frames have
+# non-None defaults, so an explicit value is indistinguishable from the
+# default and they are left out.
+DIAGNOSE_IGNORED_FLAGS = (
+    ("num_colors", "-c/--colors"),
+    ("scale_result", "-s/--scale-result"),
+    ("transparent_background", "-t/--transparent"),
+    ("pixel_width", "-w/--pixel-width"),
+    ("initial_upscale_factor", "-u/--initial-upscale"),
+    ("config", "--config"),
+    ("intermediate_dir", "--intermediate-dir"),
+    ("output_format", "-f/--format"),
+)
+
+
+def warn_ignored_diagnose_flags(args: argparse.Namespace) -> None:
+    """Warn about explicitly passed flags that ``--diagnose`` ignores."""
+    names = [
+        name
+        for dest, name in DIAGNOSE_IGNORED_FLAGS
+        if getattr(args, dest, None) is not None
+    ]
+
+    if names:
+        print(f"Warning: --diagnose ignores: {', '.join(names)}", file=sys.stderr)
 
 
 def run_diagnostics(input_path: Path) -> None:
@@ -287,6 +320,8 @@ def main() -> None:
                 "--diagnose currently supports still images only. "
                 "Video and GIF diagnostics are not supported yet."
             )
+
+        warn_ignored_diagnose_flags(args)
 
         run_diagnostics(input_path)
         return

--- a/proper_pixel_art/diagnostics.py
+++ b/proper_pixel_art/diagnostics.py
@@ -1,7 +1,8 @@
 """Diagnostics for source images prior to pixel-art cleanup.
 
-Reports size, opaque color count, transparency stats, and a full-resolution
-noise estimate, with actionable CLI recommendations.
+Reports size, content color count, transparency stats, and a full-resolution
+noise estimate. CLI advice is derived from the measurements at formatting
+time, keeping the analysis itself presentation-free.
 """
 
 from dataclasses import dataclass
@@ -9,17 +10,18 @@ from dataclasses import dataclass
 import numpy as np
 from PIL import Image
 
-# Neighbor difference (0-255 grayscale) counted as a "strong" transition.
-_STRONG_TRANSITION = 48.0
+from proper_pixel_art.colors import ALPHA_THRESHOLD
 
-# Noise bands, calibrated against full-resolution neighbor differences:
-# clean pixel art and the repository's source assets land under the moderate
-# cut, mild grain (sigma ~= 12) reads moderate, and uniform noise reads high.
-_HIGH_MEAN, _HIGH_RATIO = 24.0, 0.25
-_MODERATE_MEAN, _MODERATE_RATIO = 10.0, 0.08
+# Minimum-neighbor difference (0-255 grayscale) that marks a pixel as
+# disagreeing strongly with every one of its neighbors.
+_STRONG_DEVIATION = 48.0
 
-# Rec. 601 luma weights, matching PIL's "L" conversion.
-_LUMA_WEIGHTS = np.array([0.299, 0.587, 0.114], dtype=np.float32)
+# Noise bands, calibrated against per-pixel minimum neighbor differences
+# (see _estimate_noise_level): clean pixel art scores ~0 at any pixel width
+# >= 2, the repository's source assets land under the moderate cut, mild
+# grain (sigma ~= 12) reads moderate, and uniform noise reads high.
+_HIGH_MEAN, _HIGH_RATIO = 10.0, 0.08
+_MODERATE_MEAN, _MODERATE_RATIO = 4.0, 0.02
 
 
 @dataclass(frozen=True)
@@ -32,12 +34,11 @@ class ImageDiagnostics:
     transparent_pixels: int
     semi_transparent_pixels: int
     noise_level: str
-    recommendations: tuple[str, ...]
 
 
-def _count_opaque_colors(rgba: np.ndarray, opaque: np.ndarray) -> int:
-    """Count distinct RGB values among pixels that carry any opacity."""
-    rgb = rgba[..., :3][opaque].astype(np.uint32)
+def _count_content_colors(rgba: np.ndarray, content: np.ndarray) -> int:
+    """Count distinct RGB values among content pixels."""
+    rgb = rgba[..., :3][content].astype(np.uint32)
 
     if rgb.size == 0:
         return 0
@@ -51,42 +52,52 @@ def _count_opaque_colors(rgba: np.ndarray, opaque: np.ndarray) -> int:
     return 1 + int(np.count_nonzero(np.diff(ordered)))
 
 
-def _estimate_noise_level(rgba: np.ndarray, opaque: np.ndarray) -> str:
+def _estimate_noise_level(gray: np.ndarray, content: np.ndarray) -> str:
     """Estimate high-frequency variation in an image.
 
-    This is a lightweight heuristic, not a machine-learning classifier. It
-    compares neighboring grayscale pixels at full resolution; downscaling
-    first would low-pass away the very signal being measured.
+    Measures, for every content pixel, the minimum absolute grayscale
+    difference to its 4-neighbors. A pixel inside a flat run has at least one
+    identical neighbor and scores zero, so clean pixel art reads "low" at any
+    pixel width >= 2 no matter how small the upscale, while grain and noise
+    keep every pixel away from all of its neighbors. An image already at
+    native 1:1 pixel resolution has no flat runs and is indistinguishable
+    from noise here, but such an image needs no pixelation to begin with.
     """
-    # Cast to float before differencing: uint8 subtraction wraps around.
-    gray = rgba[..., :3].astype(np.float32) @ _LUMA_WEIGHTS
-
     horizontal = np.abs(np.diff(gray, axis=1))
     vertical = np.abs(np.diff(gray, axis=0))
 
-    # A pair counts only when both pixels are opaque. Masking (rather than
-    # compositing against a background) avoids counting the silhouette edge
-    # of a transparent cutout as image noise.
-    horizontal_valid = opaque[:, 1:] & opaque[:, :-1]
-    vertical_valid = opaque[1:, :] & opaque[:-1, :]
+    # A pair counts only when both pixels are content: infinity drops the
+    # pair from every minimum below. Masking (rather than compositing against
+    # a background) avoids counting the silhouette edge of a transparent
+    # cutout as image noise.
+    horizontal = np.where(content[:, 1:] & content[:, :-1], horizontal, np.inf)
+    vertical = np.where(content[1:, :] & content[:-1, :], vertical, np.inf)
 
-    differences = np.concatenate(
-        [horizontal[horizontal_valid], vertical[vertical_valid]]
-    )
+    minimum = np.full(gray.shape, np.inf, dtype=np.float32)
+    np.minimum(minimum[:, 1:], horizontal, out=minimum[:, 1:])
+    np.minimum(minimum[:, :-1], horizontal, out=minimum[:, :-1])
+    np.minimum(minimum[1:, :], vertical, out=minimum[1:, :])
+    np.minimum(minimum[:-1, :], vertical, out=minimum[:-1, :])
 
-    if differences.size == 0:
+    # Reduce in place instead of extracting the finite values into a copy.
+    measured = np.isfinite(minimum)
+    measured_count = int(np.count_nonzero(measured))
+
+    if measured_count == 0:
         return "low"
 
-    average_difference = float(differences.mean())
-    strong_transition_ratio = float((differences >= _STRONG_TRANSITION).mean())
+    average_deviation = (
+        float(minimum.sum(where=measured, dtype=np.float64)) / measured_count
+    )
+    strong_ratio = (
+        int(np.count_nonzero(measured & (minimum >= _STRONG_DEVIATION)))
+        / measured_count
+    )
 
-    if average_difference >= _HIGH_MEAN or strong_transition_ratio >= _HIGH_RATIO:
+    if average_deviation >= _HIGH_MEAN or strong_ratio >= _HIGH_RATIO:
         return "high"
 
-    if (
-        average_difference >= _MODERATE_MEAN
-        or strong_transition_ratio >= _MODERATE_RATIO
-    ):
+    if average_deviation >= _MODERATE_MEAN or strong_ratio >= _MODERATE_RATIO:
         return "moderate"
 
     return "low"
@@ -94,42 +105,60 @@ def _estimate_noise_level(rgba: np.ndarray, opaque: np.ndarray) -> str:
 
 def diagnose_image(image: Image.Image) -> ImageDiagnostics:
     """Analyze an image and return pixel-art cleanup diagnostics."""
-    rgba = np.asarray(image.convert("RGBA"))
+    rgba_image = image.convert("RGBA")
+    rgba = np.asarray(rgba_image)
+
+    # PIL's "L" mode applies the Rec. 601 luma weights a manual matmul would,
+    # several times faster and without full-image float temporaries.
+    gray = np.asarray(rgba_image.convert("L"), dtype=np.float32)
 
     height, width = rgba.shape[:2]
 
     alpha = rgba[..., 3]
 
-    # Fully transparent pixels carry no visible color, so they are excluded
-    # from both the color count and the noise estimate. Semi-transparent
-    # pixels are still content and count toward both.
-    opaque = alpha > 0
-
-    color_count = _count_opaque_colors(rgba, opaque)
+    # Content pixels are the ones pixelation will keep: at or above the same
+    # alpha threshold the pipeline uses. Anything below it is rendered fully
+    # transparent downstream, so it is excluded from both the color count and
+    # the noise estimate.
+    content = alpha >= ALPHA_THRESHOLD
 
     transparent_pixels = int(np.count_nonzero(alpha == 0))
+    fully_opaque_pixels = int(np.count_nonzero(alpha == 255))
+    semi_transparent_pixels = alpha.size - transparent_pixels - fully_opaque_pixels
 
-    semi_transparent_pixels = int(np.count_nonzero((alpha > 0) & (alpha < 255)))
+    return ImageDiagnostics(
+        width=width,
+        height=height,
+        color_count=_count_content_colors(rgba, content),
+        transparent_pixels=transparent_pixels,
+        semi_transparent_pixels=semi_transparent_pixels,
+        noise_level=_estimate_noise_level(gray, content),
+    )
 
-    noise_level = _estimate_noise_level(rgba, opaque)
 
+# Palettes larger than this usually carry stray colors worth quantizing away.
+_MANY_COLORS = 32
+
+
+def build_recommendations(diagnostics: ImageDiagnostics) -> tuple[str, ...]:
+    """Derive CLI advice from measured diagnostics."""
     recommendations: list[str] = []
 
-    if color_count > 32:
+    if diagnostics.color_count > _MANY_COLORS:
         recommendations.append("Try using --colors 16 or another smaller palette.")
 
-    if semi_transparent_pixels > 0:
+    if diagnostics.semi_transparent_pixels > 0:
         recommendations.append(
             "Semi-transparent pixels detected; "
             "review transparency handling in the output."
         )
 
-    if noise_level == "high":
+    if diagnostics.noise_level == "high":
         recommendations.append(
             "High-frequency variation detected; "
             "review the generated mesh and try --intermediate-dir."
         )
-    elif noise_level == "moderate":
+    elif diagnostics.noise_level == "moderate":
         recommendations.append(
             "Moderate image variation detected; try a few different --colors values."
         )
@@ -137,15 +166,7 @@ def diagnose_image(image: Image.Image) -> ImageDiagnostics:
     if not recommendations:
         recommendations.append("No obvious cleanup recommendation.")
 
-    return ImageDiagnostics(
-        width=width,
-        height=height,
-        color_count=color_count,
-        transparent_pixels=transparent_pixels,
-        semi_transparent_pixels=semi_transparent_pixels,
-        noise_level=noise_level,
-        recommendations=tuple(recommendations),
-    )
+    return tuple(recommendations)
 
 
 def format_diagnostics(
@@ -153,7 +174,7 @@ def format_diagnostics(
 ) -> str:
     """Format diagnostics as readable terminal output."""
     recommendations = "\n".join(
-        f"- {recommendation}" for recommendation in diagnostics.recommendations
+        f"- {recommendation}" for recommendation in build_recommendations(diagnostics)
     )
 
     return f"""Image diagnosis

--- a/proper_pixel_art/diagnostics.py
+++ b/proper_pixel_art/diagnostics.py
@@ -1,6 +1,25 @@
+"""Diagnostics for source images prior to pixel-art cleanup.
+
+Reports size, opaque color count, transparency stats, and a full-resolution
+noise estimate, with actionable CLI recommendations.
+"""
+
 from dataclasses import dataclass
 
+import numpy as np
 from PIL import Image
+
+# Neighbor difference (0-255 grayscale) counted as a "strong" transition.
+_STRONG_TRANSITION = 48.0
+
+# Noise bands, calibrated against full-resolution neighbor differences:
+# clean pixel art and the repository's source assets land under the moderate
+# cut, mild grain (sigma ~= 12) reads moderate, and uniform noise reads high.
+_HIGH_MEAN, _HIGH_RATIO = 24.0, 0.25
+_MODERATE_MEAN, _MODERATE_RATIO = 10.0, 0.08
+
+# Rec. 601 luma weights, matching PIL's "L" conversion.
+_LUMA_WEIGHTS = np.array([0.299, 0.587, 0.114], dtype=np.float32)
 
 
 @dataclass(frozen=True)
@@ -16,71 +35,58 @@ class ImageDiagnostics:
     recommendations: tuple[str, ...]
 
 
-def _estimate_noise_level(image: Image.Image) -> str:
+def _count_opaque_colors(rgba: np.ndarray, opaque: np.ndarray) -> int:
+    """Count distinct RGB values among pixels that carry any opacity."""
+    rgb = rgba[..., :3][opaque].astype(np.uint32)
+
+    if rgb.size == 0:
+        return 0
+
+    packed = (rgb[:, 0] << 16) | (rgb[:, 1] << 8) | rgb[:, 2]
+
+    # Sort and count the value changes rather than calling np.unique, which is
+    # two orders of magnitude slower on megapixel inputs with many colors.
+    ordered = np.sort(packed)
+
+    return 1 + int(np.count_nonzero(np.diff(ordered)))
+
+
+def _estimate_noise_level(rgba: np.ndarray, opaque: np.ndarray) -> str:
     """Estimate high-frequency variation in an image.
 
-    This is a lightweight heuristic, not a machine-learning classifier.
-    It compares neighboring grayscale pixels after reducing the image size.
+    This is a lightweight heuristic, not a machine-learning classifier. It
+    compares neighboring grayscale pixels at full resolution; downscaling
+    first would low-pass away the very signal being measured.
     """
+    # Cast to float before differencing: uint8 subtraction wraps around.
+    gray = rgba[..., :3].astype(np.float32) @ _LUMA_WEIGHTS
 
-    grayscale = image.convert("L")
+    horizontal = np.abs(np.diff(gray, axis=1))
+    vertical = np.abs(np.diff(gray, axis=0))
 
-    max_dimension = max(grayscale.size)
+    # A pair counts only when both pixels are opaque. Masking (rather than
+    # compositing against a background) avoids counting the silhouette edge
+    # of a transparent cutout as image noise.
+    horizontal_valid = opaque[:, 1:] & opaque[:, :-1]
+    vertical_valid = opaque[1:, :] & opaque[:-1, :]
 
-    if max_dimension > 128:
-        scale = 128 / max_dimension
-        resized_size = (
-            max(1, round(grayscale.width * scale)),
-            max(1, round(grayscale.height * scale)),
-        )
-        grayscale = grayscale.resize(
-            resized_size,
-            Image.Resampling.BILINEAR,
-        )
+    differences = np.concatenate(
+        [horizontal[horizontal_valid], vertical[vertical_valid]]
+    )
 
-    width, height = grayscale.size
-
-    if width < 2 or height < 2:
+    if differences.size == 0:
         return "low"
 
-    pixels = list(grayscale.getdata())
+    average_difference = float(differences.mean())
+    strong_transition_ratio = float((differences >= _STRONG_TRANSITION).mean())
 
-    total_difference = 0
-    comparisons = 0
-    strong_transitions = 0
-
-    for y in range(height):
-        row_start = y * width
-
-        for x in range(width):
-            current = pixels[row_start + x]
-
-            if x + 1 < width:
-                difference = abs(current - pixels[row_start + x + 1])
-                total_difference += difference
-                comparisons += 1
-
-                if difference >= 48:
-                    strong_transitions += 1
-
-            if y + 1 < height:
-                difference = abs(current - pixels[row_start + width + x])
-                total_difference += difference
-                comparisons += 1
-
-                if difference >= 48:
-                    strong_transitions += 1
-
-    if comparisons == 0:
-        return "low"
-
-    average_difference = total_difference / comparisons
-    strong_transition_ratio = strong_transitions / comparisons
-
-    if average_difference >= 32 or strong_transition_ratio >= 0.35:
+    if average_difference >= _HIGH_MEAN or strong_transition_ratio >= _HIGH_RATIO:
         return "high"
 
-    if average_difference >= 16 or strong_transition_ratio >= 0.18:
+    if (
+        average_difference >= _MODERATE_MEAN
+        or strong_transition_ratio >= _MODERATE_RATIO
+    ):
         return "moderate"
 
     return "low"
@@ -88,21 +94,24 @@ def _estimate_noise_level(image: Image.Image) -> str:
 
 def diagnose_image(image: Image.Image) -> ImageDiagnostics:
     """Analyze an image and return pixel-art cleanup diagnostics."""
-    rgba_image = image.convert("RGBA")
+    rgba = np.asarray(image.convert("RGBA"))
 
-    width, height = rgba_image.size
+    height, width = rgba.shape[:2]
 
-    colors = rgba_image.convert("RGB").getcolors(maxcolors=16_777_216)
+    alpha = rgba[..., 3]
 
-    color_count = len(colors) if colors is not None else 16_777_217
+    # Fully transparent pixels carry no visible color, so they are excluded
+    # from both the color count and the noise estimate. Semi-transparent
+    # pixels are still content and count toward both.
+    opaque = alpha > 0
 
-    alpha_values = list(rgba_image.getchannel("A").getdata())
+    color_count = _count_opaque_colors(rgba, opaque)
 
-    transparent_pixels = sum(alpha == 0 for alpha in alpha_values)
+    transparent_pixels = int(np.count_nonzero(alpha == 0))
 
-    semi_transparent_pixels = sum(0 < alpha < 255 for alpha in alpha_values)
+    semi_transparent_pixels = int(np.count_nonzero((alpha > 0) & (alpha < 255)))
 
-    noise_level = _estimate_noise_level(rgba_image)
+    noise_level = _estimate_noise_level(rgba, opaque)
 
     recommendations: list[str] = []
 

--- a/proper_pixel_art/diagnostics.py
+++ b/proper_pixel_art/diagnostics.py
@@ -1,0 +1,160 @@
+from dataclasses import dataclass
+
+from PIL import Image
+
+
+@dataclass(frozen=True)
+class ImageDiagnostics:
+    """Summary of image characteristics relevant to pixel-art cleanup."""
+
+    width: int
+    height: int
+    color_count: int
+    transparent_pixels: int
+    semi_transparent_pixels: int
+    noise_level: str
+    recommendations: tuple[str, ...]
+
+
+def _estimate_noise_level(image: Image.Image) -> str:
+    """Estimate high-frequency variation in an image.
+
+    This is a lightweight heuristic, not a machine-learning classifier.
+    It compares neighboring grayscale pixels after reducing the image size.
+    """
+
+    grayscale = image.convert("L")
+
+    max_dimension = max(grayscale.size)
+
+    if max_dimension > 128:
+        scale = 128 / max_dimension
+        resized_size = (
+            max(1, round(grayscale.width * scale)),
+            max(1, round(grayscale.height * scale)),
+        )
+        grayscale = grayscale.resize(
+            resized_size,
+            Image.Resampling.BILINEAR,
+        )
+
+    width, height = grayscale.size
+
+    if width < 2 or height < 2:
+        return "low"
+
+    pixels = list(grayscale.getdata())
+
+    total_difference = 0
+    comparisons = 0
+    strong_transitions = 0
+
+    for y in range(height):
+        row_start = y * width
+
+        for x in range(width):
+            current = pixels[row_start + x]
+
+            if x + 1 < width:
+                difference = abs(current - pixels[row_start + x + 1])
+                total_difference += difference
+                comparisons += 1
+
+                if difference >= 48:
+                    strong_transitions += 1
+
+            if y + 1 < height:
+                difference = abs(current - pixels[row_start + width + x])
+                total_difference += difference
+                comparisons += 1
+
+                if difference >= 48:
+                    strong_transitions += 1
+
+    if comparisons == 0:
+        return "low"
+
+    average_difference = total_difference / comparisons
+    strong_transition_ratio = strong_transitions / comparisons
+
+    if average_difference >= 32 or strong_transition_ratio >= 0.35:
+        return "high"
+
+    if average_difference >= 16 or strong_transition_ratio >= 0.18:
+        return "moderate"
+
+    return "low"
+
+
+def diagnose_image(image: Image.Image) -> ImageDiagnostics:
+    """Analyze an image and return pixel-art cleanup diagnostics."""
+    rgba_image = image.convert("RGBA")
+
+    width, height = rgba_image.size
+
+    colors = rgba_image.convert("RGB").getcolors(maxcolors=16_777_216)
+
+    color_count = len(colors) if colors is not None else 16_777_217
+
+    alpha_values = list(rgba_image.getchannel("A").getdata())
+
+    transparent_pixels = sum(alpha == 0 for alpha in alpha_values)
+
+    semi_transparent_pixels = sum(0 < alpha < 255 for alpha in alpha_values)
+
+    noise_level = _estimate_noise_level(rgba_image)
+
+    recommendations: list[str] = []
+
+    if color_count > 32:
+        recommendations.append("Try using --colors 16 or another smaller palette.")
+
+    if semi_transparent_pixels > 0:
+        recommendations.append(
+            "Semi-transparent pixels detected; "
+            "review transparency handling in the output."
+        )
+
+    if noise_level == "high":
+        recommendations.append(
+            "High-frequency variation detected; "
+            "review the generated mesh and try --intermediate-dir."
+        )
+    elif noise_level == "moderate":
+        recommendations.append(
+            "Moderate image variation detected; try a few different --colors values."
+        )
+
+    if not recommendations:
+        recommendations.append("No obvious cleanup recommendation.")
+
+    return ImageDiagnostics(
+        width=width,
+        height=height,
+        color_count=color_count,
+        transparent_pixels=transparent_pixels,
+        semi_transparent_pixels=semi_transparent_pixels,
+        noise_level=noise_level,
+        recommendations=tuple(recommendations),
+    )
+
+
+def format_diagnostics(
+    diagnostics: ImageDiagnostics,
+) -> str:
+    """Format diagnostics as readable terminal output."""
+    recommendations = "\n".join(
+        f"- {recommendation}" for recommendation in diagnostics.recommendations
+    )
+
+    return f"""Image diagnosis
+---------------
+Size: {diagnostics.width}x{diagnostics.height}
+Estimated colors: {diagnostics.color_count}
+Transparent pixels: {diagnostics.transparent_pixels}
+Semi-transparent pixels: {diagnostics.semi_transparent_pixels}
+Noise level: {diagnostics.noise_level}
+
+Recommendations:
+{recommendations}
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ CONTRIBUTING.md -> Visual validation.
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -117,7 +118,8 @@ def test_parse_args_positional_input(monkeypatch: pytest.MonkeyPatch) -> None:
     assert args.intermediate_dir is None
     assert args.transparent_background is None
     assert args.output_format is None
-    assert args.sample_frames == 8
+    assert args.sample_frames is None
+    assert args.out_path is None
     assert args.diagnose is False
 
 
@@ -194,6 +196,45 @@ def test_main_diagnose_warns_on_ignored_flags(
 
     run_cli(monkeypatch, str(input_path), "--diagnose")
     assert capsys.readouterr().err == ""
+
+
+def test_main_diagnose_warns_on_ignored_output_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    assets: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """-o is inert under --diagnose too: the report only goes to stdout."""
+    input_path = assets / "anchor" / "anchor.png"
+    out_path = tmp_path / "report.txt"
+
+    run_cli(monkeypatch, str(input_path), "--diagnose", "-o", str(out_path))
+
+    assert "-o/--output" in capsys.readouterr().err
+    assert not out_path.exists()
+
+
+def test_main_reports_missing_vs_unreadable_input(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A permission-blocked input is reported as unreadable, not missing."""
+    with pytest.raises(SystemExit, match="does not exist"):
+        run_cli(monkeypatch, str(tmp_path / "missing.png"))
+
+    if os.geteuid() == 0:
+        pytest.skip("permissions are not enforced for root")
+
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+    input_path = blocked_dir / "sprite.png"
+    input_path.touch()
+    blocked_dir.chmod(0o000)
+
+    try:
+        with pytest.raises(SystemExit, match="Cannot access input file"):
+            run_cli(monkeypatch, str(input_path))
+    finally:
+        blocked_dir.chmod(0o755)
 
 
 def test_ppa_video_alias_deprecated(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ and argument errors. Visual quality is validated separately by eye -- see
 CONTRIBUTING.md -> Visual validation.
 """
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -117,6 +118,7 @@ def test_parse_args_positional_input(monkeypatch: pytest.MonkeyPatch) -> None:
     assert args.transparent_background is None
     assert args.output_format is None
     assert args.sample_frames == 8
+    assert args.diagnose is False
 
 
 def test_parse_args_input_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -137,6 +139,61 @@ def test_parse_args_video_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     args = cli.parse_args()
     assert args.output_format == "mp4"
     assert args.sample_frames == 4
+
+
+def test_parse_args_diagnose_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["ppa", "in.png", "--diagnose"])
+    assert cli.parse_args().diagnose is True
+
+
+def test_add_pixelation_args_excludes_diagnose() -> None:
+    """--diagnose belongs to `ppa` only, not the shared pixelation helper that
+    scripts/ppa_gen.py reuses."""
+    parser = cli.add_pixelation_args(argparse.ArgumentParser())
+
+    assert "--diagnose" not in parser.format_help()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--diagnose"])
+
+
+def test_main_diagnose_prints_report(
+    monkeypatch: pytest.MonkeyPatch,
+    assets: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--diagnose reports on the image instead of writing an output file."""
+    input_path = assets / "anchor" / "anchor.png"
+
+    run_cli(monkeypatch, str(input_path), "--diagnose")
+
+    stdout = capsys.readouterr().out
+    assert "Image diagnosis" in stdout
+    assert "Size: 500x500" in stdout
+    assert "Noise level: low" in stdout
+
+
+def test_main_diagnose_rejects_video(
+    monkeypatch: pytest.MonkeyPatch, gif_path: Path
+) -> None:
+    with pytest.raises(SystemExit, match="still images"):
+        run_cli(monkeypatch, str(gif_path), "--diagnose")
+
+
+def test_main_diagnose_warns_on_ignored_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    assets: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Pixelation flags are inert under --diagnose, so they get called out."""
+    input_path = assets / "anchor" / "anchor.png"
+
+    run_cli(monkeypatch, str(input_path), "--diagnose", "-c", "8")
+    stderr = capsys.readouterr().err
+    assert "--diagnose ignores" in stderr
+    assert "-c/--colors" in stderr
+
+    run_cli(monkeypatch, str(input_path), "--diagnose")
+    assert capsys.readouterr().err == ""
 
 
 def test_ppa_video_alias_deprecated(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,120 @@
+"""Tests for the ``--diagnose`` image analysis helpers.
+
+All inputs are synthetic and seeded, so noise levels and color counts are
+reproducible without committing binary assets.
+"""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from proper_pixel_art.diagnostics import diagnose_image, format_diagnostics
+
+
+def _rgb_image(array: np.ndarray) -> Image.Image:
+    return Image.fromarray(array.astype(np.uint8), mode="RGB")
+
+
+def test_noise_high_for_random_noise() -> None:
+    """Uniform random pixels read as high noise at full resolution."""
+    rng = np.random.default_rng(0)
+    image = _rgb_image(rng.integers(0, 256, (256, 256, 3), dtype=np.uint8))
+
+    diagnostics = diagnose_image(image)
+
+    assert diagnostics.noise_level == "high"
+    assert any(
+        "High-frequency variation" in recommendation
+        for recommendation in diagnostics.recommendations
+    )
+
+
+def test_noise_low_for_clean_pixel_art() -> None:
+    """Nearest-neighbor upscaled pixel art is flat inside each block."""
+    rng = np.random.default_rng(1)
+    cells = _rgb_image(rng.integers(0, 256, (32, 32, 3), dtype=np.uint8))
+    image = cells.resize((512, 512), Image.Resampling.NEAREST)
+
+    assert diagnose_image(image).noise_level == "low"
+
+
+def test_noise_moderate_for_mild_grain() -> None:
+    """Flat gray with sigma ~= 12 grain lands between the low and high bands."""
+    rng = np.random.default_rng(1234)
+    grain = np.clip(128 + rng.normal(0, 12, (256, 256)), 0, 255)
+    image = _rgb_image(np.repeat(grain[:, :, None], 3, axis=2))
+
+    diagnostics = diagnose_image(image)
+
+    assert diagnostics.noise_level == "moderate"
+    assert any(
+        "Moderate image variation" in recommendation
+        for recommendation in diagnostics.recommendations
+    )
+
+
+def test_transparent_pixels_excluded() -> None:
+    """A fully transparent image yields no colors, no noise, and no advice."""
+    rng = np.random.default_rng(2)
+    rgba = np.empty((64, 64, 4), dtype=np.uint8)
+    rgba[..., :3] = rng.integers(0, 256, (64, 64, 3), dtype=np.uint8)
+    rgba[..., 3] = 0
+
+    diagnostics = diagnose_image(Image.fromarray(rgba, mode="RGBA"))
+
+    assert diagnostics.noise_level == "low"
+    assert diagnostics.color_count == 0
+    assert diagnostics.transparent_pixels == 64 * 64
+    assert diagnostics.semi_transparent_pixels == 0
+    assert diagnostics.recommendations == ("No obvious cleanup recommendation.",)
+
+
+@pytest.mark.parametrize(
+    ("num_colors", "expect_palette_recommendation"), [(4, False), (40, True)]
+)
+def test_color_count_ignores_transparent_colors(
+    num_colors: int, expect_palette_recommendation: bool
+) -> None:
+    """Colors hidden under alpha == 0 do not inflate the count."""
+    rgba = np.zeros((64, 64, 4), dtype=np.uint8)
+    # Opaque band: one distinct color per row, cycling through the palette.
+    palette = np.arange(num_colors, dtype=np.uint8)
+    rgba[:48, :, 0] = palette[np.arange(48) % num_colors][:, None]
+    rgba[:48, :, 3] = 255
+    # Transparent band, holding a color found nowhere in the opaque band.
+    rgba[48:, :, :3] = 200
+
+    diagnostics = diagnose_image(Image.fromarray(rgba, mode="RGBA"))
+
+    assert diagnostics.color_count == num_colors
+    has_palette_recommendation = any(
+        "--colors 16" in recommendation
+        for recommendation in diagnostics.recommendations
+    )
+    assert has_palette_recommendation is expect_palette_recommendation
+
+
+def test_alpha_counts() -> None:
+    """Alpha 0 counts as transparent; anything in (0, 255) as semi."""
+    rgba = np.zeros((2, 2, 4), dtype=np.uint8)
+    rgba[..., 3] = np.array([[0, 128], [255, 7]], dtype=np.uint8)
+
+    diagnostics = diagnose_image(Image.fromarray(rgba, mode="RGBA"))
+
+    assert diagnostics.transparent_pixels == 1
+    assert diagnostics.semi_transparent_pixels == 2
+    assert any(
+        "Semi-transparent pixels detected" in recommendation
+        for recommendation in diagnostics.recommendations
+    )
+
+
+def test_format_diagnostics_output() -> None:
+    """The report includes the size, noise level, and bulleted advice."""
+    image = _rgb_image(np.zeros((8, 4, 3), dtype=np.uint8))
+
+    report = format_diagnostics(diagnose_image(image))
+
+    assert "Size: 4x8" in report
+    assert "Noise level: low" in report
+    assert "\n- " in report

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,7 +8,12 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from proper_pixel_art.diagnostics import diagnose_image, format_diagnostics
+from proper_pixel_art.colors import ALPHA_THRESHOLD
+from proper_pixel_art.diagnostics import (
+    build_recommendations,
+    diagnose_image,
+    format_diagnostics,
+)
 
 
 def _rgb_image(array: np.ndarray) -> Image.Image:
@@ -25,7 +30,7 @@ def test_noise_high_for_random_noise() -> None:
     assert diagnostics.noise_level == "high"
     assert any(
         "High-frequency variation" in recommendation
-        for recommendation in diagnostics.recommendations
+        for recommendation in build_recommendations(diagnostics)
     )
 
 
@@ -34,6 +39,18 @@ def test_noise_low_for_clean_pixel_art() -> None:
     rng = np.random.default_rng(1)
     cells = _rgb_image(rng.integers(0, 256, (32, 32, 3), dtype=np.uint8))
     image = cells.resize((512, 512), Image.Resampling.NEAREST)
+
+    assert diagnose_image(image).noise_level == "low"
+
+
+@pytest.mark.parametrize("pixel_width", [2, 3, 4, 6])
+def test_noise_low_for_small_pixel_widths(pixel_width: int) -> None:
+    """Clean art reads low even when its pixels are only a few image pixels
+    wide, where boundary transitions dominate the neighbor-pair population."""
+    rng = np.random.default_rng(1)
+    cells = _rgb_image(rng.integers(0, 256, (32, 32, 3), dtype=np.uint8))
+    size = 32 * pixel_width
+    image = cells.resize((size, size), Image.Resampling.NEAREST)
 
     assert diagnose_image(image).noise_level == "low"
 
@@ -49,8 +66,25 @@ def test_noise_moderate_for_mild_grain() -> None:
     assert diagnostics.noise_level == "moderate"
     assert any(
         "Moderate image variation" in recommendation
-        for recommendation in diagnostics.recommendations
+        for recommendation in build_recommendations(diagnostics)
     )
+
+
+def test_noise_moderate_for_grainy_pixel_art() -> None:
+    """Upscaled art with grain on top -- the AI-generated failure mode
+    --diagnose exists for -- is flagged rather than passed as clean."""
+    rng = np.random.default_rng(1)
+    cells = rng.integers(0, 256, (32, 32, 3), dtype=np.uint8)
+    upscaled = np.asarray(
+        _rgb_image(cells).resize((256, 256), Image.Resampling.NEAREST),
+        dtype=np.float64,
+    )
+    # Grain is shared across channels; independent per-channel noise partly
+    # averages out in the luma the estimate is computed on.
+    grain = rng.normal(0, 12, upscaled.shape[:2])
+    noisy = np.clip(upscaled + grain[:, :, None], 0, 255)
+
+    assert diagnose_image(_rgb_image(noisy)).noise_level != "low"
 
 
 def test_transparent_pixels_excluded() -> None:
@@ -66,7 +100,7 @@ def test_transparent_pixels_excluded() -> None:
     assert diagnostics.color_count == 0
     assert diagnostics.transparent_pixels == 64 * 64
     assert diagnostics.semi_transparent_pixels == 0
-    assert diagnostics.recommendations == ("No obvious cleanup recommendation.",)
+    assert build_recommendations(diagnostics) == ("No obvious cleanup recommendation.",)
 
 
 @pytest.mark.parametrize(
@@ -89,9 +123,21 @@ def test_color_count_ignores_transparent_colors(
     assert diagnostics.color_count == num_colors
     has_palette_recommendation = any(
         "--colors 16" in recommendation
-        for recommendation in diagnostics.recommendations
+        for recommendation in build_recommendations(diagnostics)
     )
     assert has_palette_recommendation is expect_palette_recommendation
+
+
+def test_color_count_uses_pipeline_alpha_threshold() -> None:
+    """Colors below colors.ALPHA_THRESHOLD are rendered fully transparent by
+    the pipeline, so they do not count as content."""
+    rgba = np.zeros((8, 8, 4), dtype=np.uint8)
+    rgba[..., 3] = 255
+    # A second color, hidden below the pipeline's opacity threshold.
+    rgba[0, :, :3] = 200
+    rgba[0, :, 3] = ALPHA_THRESHOLD - 1
+
+    assert diagnose_image(Image.fromarray(rgba, mode="RGBA")).color_count == 1
 
 
 def test_alpha_counts() -> None:
@@ -105,7 +151,7 @@ def test_alpha_counts() -> None:
     assert diagnostics.semi_transparent_pixels == 2
     assert any(
         "Semi-transparent pixels detected" in recommendation
-        for recommendation in diagnostics.recommendations
+        for recommendation in build_recommendations(diagnostics)
     )
 
 


### PR DESCRIPTION
## Summary

Adds a new `--diagnose` CLI mode for analyzing noisy or imperfect
AI-generated pixel-art-style images before pixelation.

## Usage

```bash
ppa input.png --diagnose
```

The diagnostic report includes:

- Input image dimensions
- Estimated color count
- Transparent pixel count
- Semi-transparent pixel count
- Basic noise-level estimate
- Cleanup recommendations

Example recommendations include trying a smaller color palette or reviewing
transparency handling.

## Implementation

- Added `proper_pixel_art/diagnostics.py`
- Added the `--diagnose` option to `proper_pixel_art/cli.py`
- Kept diagnostics local and deterministic
- Added no external AI or API dependencies
- Preserved the existing pixelation behavior
- Prevented `--diagnose` from being used with video and GIF inputs

## Why

AI-generated images often look like pixel art but contain:

- Excessive colors
- Semi-transparent pixels
- Visual noise
- Inconsistent image details

This feature helps users inspect the input and choose better pixelation
parameters before generating the final output.

## Testing

- `uv run ruff format`
- `uv run ruff check`
- `uv run pytest`
- Manual test with:

```bash
uv run ppa assets/blob/blob.png --diagnose
uv run ppa assets/blob/blob.png -c 16
uv run ppa assets/blob/blob.png -c 16 --intermediate-dir tests/outputs
```

Test result:

```text
81 passed, 6 skipped
```

## Scope

This PR does not modify the existing pixelation algorithm or committed visual
reference assets.